### PR TITLE
14 닉네임 중복 확인

### DIFF
--- a/src/main/java/com/dopamingu/be/domain/member/application/MemberService.java
+++ b/src/main/java/com/dopamingu/be/domain/member/application/MemberService.java
@@ -1,0 +1,22 @@
+package com.dopamingu.be.domain.member.application;
+
+import com.dopamingu.be.domain.member.dao.MemberRepository;
+import com.dopamingu.be.domain.member.dto.response.UsernameAvailableResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public UsernameAvailableResponseDto checkUsernameDuplicate(String desiredUsername) {
+        return new UsernameAvailableResponseDto(
+            !memberRepository.existsMemberByUsername(desiredUsername));
+    }
+}

--- a/src/main/java/com/dopamingu/be/domain/member/application/MemberService.java
+++ b/src/main/java/com/dopamingu/be/domain/member/application/MemberService.java
@@ -17,6 +17,6 @@ public class MemberService {
 
     public UsernameAvailableResponseDto checkUsernameDuplicate(String desiredUsername) {
         return new UsernameAvailableResponseDto(
-            !memberRepository.existsMemberByUsername(desiredUsername));
+                !memberRepository.existsMemberByUsername(desiredUsername));
     }
 }

--- a/src/main/java/com/dopamingu/be/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dopamingu/be/domain/member/controller/MemberController.java
@@ -1,0 +1,23 @@
+package com.dopamingu.be.domain.member.controller;
+
+import com.dopamingu.be.domain.member.application.MemberService;
+import com.dopamingu.be.domain.member.controller.docs.MemberControllerDocs;
+import com.dopamingu.be.domain.member.dto.response.UsernameAvailableResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController implements MemberControllerDocs {
+
+    private final MemberService memberService;
+
+    @GetMapping("/check-username")
+    public UsernameAvailableResponseDto checkUsername(@RequestParam String desiredUsername) {
+        return memberService.checkUsernameDuplicate(desiredUsername);
+    }
+}

--- a/src/main/java/com/dopamingu/be/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/dopamingu/be/domain/member/controller/docs/MemberControllerDocs.java
@@ -1,0 +1,13 @@
+package com.dopamingu.be.domain.member.controller.docs;
+
+import com.dopamingu.be.domain.member.dto.response.UsernameAvailableResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "회원 관련", description = "회원 관련 API")
+public interface MemberControllerDocs {
+
+    @Operation(summary = "닉네임 중복확인", description = "사용자 요청 닉네임 중복여부 확인 API")
+    public UsernameAvailableResponseDto checkUsername(@RequestParam String desiredUsername);
+}

--- a/src/main/java/com/dopamingu/be/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/dopamingu/be/domain/member/dao/MemberRepository.java
@@ -10,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
+
+    boolean existsMemberByUsername(String username);
 }

--- a/src/main/java/com/dopamingu/be/domain/member/dto/response/UsernameAvailableResponseDto.java
+++ b/src/main/java/com/dopamingu/be/domain/member/dto/response/UsernameAvailableResponseDto.java
@@ -1,0 +1,13 @@
+package com.dopamingu.be.domain.member.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class UsernameAvailableResponseDto {
+
+    private final boolean available;
+
+    public UsernameAvailableResponseDto(boolean available) {
+        this.available = available;
+    }
+}


### PR DESCRIPTION
## 💡 Issue
- #14 

## 📌 Work Description
## 🎯 목적
- 닉네임 등록 전 닉네임 중복 확인 API 별도 구현

## 🔍 구현 내용

### 1. Member 관련 API 
- `members/check-username` 입력 받은 유저 닉네임으로 등록 가능 여부 확인(`MemberController`, `MemberService`, `MemberRepository`)
- 등록가능여부 응답 전달 (`UsernameAvailableResponseDto`) 

## ✅ 테스트 항목
- [ ] username 중복일 경우,  available : false 반환
- [ ] username 없을 경우,  available : true 반환

## 📝 Reference
- 

## 📚 Etc
- 