### PR TITLE
Comment/42 에피소드 댓글 생성

### DIFF
--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -79,9 +79,8 @@ public class EpisodeController implements EpisodeControllerDocs {
 
     @PostMapping("/{episodeId}/comments")
     public Long createEpisodeComment(
-        @PathVariable Long episodeId,
-        @Valid @RequestBody EpisodeCommentCreateRequest episodeCommentCreateRequest) {
+            @PathVariable Long episodeId,
+            @Valid @RequestBody EpisodeCommentCreateRequest episodeCommentCreateRequest) {
         return episodeCommentService.createEpisodeComment(episodeId, episodeCommentCreateRequest);
     }
-
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -1,12 +1,14 @@
 package com.dopamingu.be.domain.episode.controller;
 
 import com.dopamingu.be.domain.episode.controller.docs.EpisodeControllerDocs;
+import com.dopamingu.be.domain.episode.dto.EpisodeCommentCreateRequest;
 import com.dopamingu.be.domain.episode.dto.EpisodeCreateRequest;
 import com.dopamingu.be.domain.episode.dto.EpisodeCreateResponse;
 import com.dopamingu.be.domain.episode.dto.EpisodeDetailGetResponse;
 import com.dopamingu.be.domain.episode.dto.EpisodeListGetResponse;
 import com.dopamingu.be.domain.episode.dto.EpisodeUpdateRequest;
 import com.dopamingu.be.domain.episode.dto.EpisodeUpdateResponse;
+import com.dopamingu.be.domain.episode.service.EpisodeCommentService;
 import com.dopamingu.be.domain.episode.service.EpisodeLikeService;
 import com.dopamingu.be.domain.episode.service.EpisodeService;
 import jakarta.validation.Valid;
@@ -30,6 +32,7 @@ public class EpisodeController implements EpisodeControllerDocs {
 
     private final EpisodeService episodeService;
     private final EpisodeLikeService episodeLikeService;
+    private final EpisodeCommentService episodeCommentService;
 
     @PostMapping
     public EpisodeCreateResponse createEpisode(
@@ -73,4 +76,12 @@ public class EpisodeController implements EpisodeControllerDocs {
         episodeLikeService.unlikeEpisode(episodeId);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/{episodeId}/comments")
+    public Long createEpisodeComment(
+        @PathVariable Long episodeId,
+        @Valid @RequestBody EpisodeCommentCreateRequest episodeCommentCreateRequest) {
+        return episodeCommentService.createEpisodeComment(episodeId, episodeCommentCreateRequest);
+    }
+
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/domain/EpisodeComment.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/domain/EpisodeComment.java
@@ -35,11 +35,9 @@ public class EpisodeComment extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private ContentStatus contentStatus;
 
-    @NotNull
-    private String creatorName;
+    @NotNull private String creatorName;
 
-    @Length(max = 100)
-    private String content;
+    @Length(max = 100) private String content;
 
     @ManyToOne
     @JoinColumn(name = "parent_id")
@@ -61,12 +59,12 @@ public class EpisodeComment extends BaseTimeEntity {
 
     @Builder
     private EpisodeComment(
-        ContentStatus contentStatus,
-        String creatorName,
-        String content,
-        EpisodeComment parent,
-        Episode episode,
-        Member member) {
+            ContentStatus contentStatus,
+            String creatorName,
+            String content,
+            EpisodeComment parent,
+            Episode episode,
+            Member member) {
         this.contentStatus = contentStatus;
         this.creatorName = creatorName;
         this.content = content;

--- a/src/main/java/com/dopamingu/be/domain/episode/domain/EpisodeComment.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/domain/EpisodeComment.java
@@ -1,0 +1,77 @@
+package com.dopamingu.be.domain.episode.domain;
+
+import com.dopamingu.be.domain.common.model.BaseTimeEntity;
+import com.dopamingu.be.domain.member.domain.Member;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EpisodeComment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "episode_comment_id")
+    private Long id;
+
+    @Enumerated(value = EnumType.STRING)
+    private ContentStatus contentStatus;
+
+    @NotNull
+    private String creatorName;
+
+    @Length(max = 100)
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private EpisodeComment parent = null;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<EpisodeComment> subComments = new ArrayList<>();
+
+    @Column(name = "likes")
+    private int likes = 0;
+
+    @ManyToOne
+    @JoinColumn(name = "episode_id")
+    private Episode episode;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    private EpisodeComment(
+        ContentStatus contentStatus,
+        String creatorName,
+        String content,
+        EpisodeComment parent,
+        Episode episode,
+        Member member) {
+        this.contentStatus = contentStatus;
+        this.creatorName = creatorName;
+        this.content = content;
+        this.parent = parent;
+        this.episode = episode;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentCreateRequest.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentCreateRequest.java
@@ -1,0 +1,13 @@
+package com.dopamingu.be.domain.episode.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class EpisodeCommentCreateRequest {
+
+    @NotBlank(message = "댓글의 내용을 입력해주세요,")
+    @Size(max = 100)
+    private String content;
+}

--- a/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
@@ -10,7 +10,7 @@ public interface EpisodeCommentRepository extends JpaRepository<EpisodeComment, 
 
     Optional<EpisodeComment> findFirstByMemberIdAndEpisodeId(Long memberId, Long episodeId);
 
-    @Query("SELECT COUNT(DISTINCT ec.member.id) FROM EpisodeComment ec WHERE ec.episode.id = :episodeId")
+    @Query(
+            "SELECT COUNT(DISTINCT ec.member.id) FROM EpisodeComment ec WHERE ec.episode.id = :episodeId")
     long countDistinctMembersByEpisode(@Param("episodeId") Long episodeId);
-
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
@@ -1,0 +1,16 @@
+package com.dopamingu.be.domain.episode.repository;
+
+import com.dopamingu.be.domain.episode.domain.EpisodeComment;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EpisodeCommentRepository extends JpaRepository<EpisodeComment, Long> {
+
+    Optional<EpisodeComment> findFirstByMemberIdAndEpisodeId(Long memberId, Long episodeId);
+
+    @Query("SELECT COUNT(DISTINCT ec.member.id) FROM EpisodeComment ec WHERE ec.episode.id = :episodeId")
+    long countDistinctMembersByEpisode(@Param("episodeId") Long episodeId);
+
+}

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -1,0 +1,85 @@
+package com.dopamingu.be.domain.episode.service;
+
+import com.dopamingu.be.domain.episode.domain.ContentStatus;
+import com.dopamingu.be.domain.episode.domain.Episode;
+import com.dopamingu.be.domain.episode.domain.EpisodeComment;
+import com.dopamingu.be.domain.episode.dto.EpisodeCommentCreateRequest;
+import com.dopamingu.be.domain.episode.repository.EpisodeCommentRepository;
+import com.dopamingu.be.domain.episode.repository.EpisodeRepository;
+import com.dopamingu.be.domain.global.error.exception.CustomException;
+import com.dopamingu.be.domain.global.error.exception.ErrorCode;
+import com.dopamingu.be.domain.global.util.MemberUtil;
+import com.dopamingu.be.domain.member.domain.Member;
+import com.dopamingu.be.domain.member.domain.MemberStatus;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EpisodeCommentService {
+
+    private final EpisodeCommentRepository episodeCommentRepository;
+    private final EpisodeRepository episodeRepository;
+    private final MemberUtil memberUtil;
+
+    public EpisodeCommentService(EpisodeCommentRepository episodeCommentRepository,
+        EpisodeRepository episodeRepository,
+        MemberUtil memberUtil) {
+        this.episodeCommentRepository = episodeCommentRepository;
+        this.episodeRepository = episodeRepository;
+        this.memberUtil = memberUtil;
+    }
+
+    public Long createEpisodeComment(Long episodeId,
+        EpisodeCommentCreateRequest episodeCommentCreateRequest) {
+
+        // 회원 확인
+        Member member = memberUtil.getCurrentMember();
+        checkMemberStatus(member);
+
+        // Episode 확인
+        Episode episode = getEpisode(episodeId);
+
+        EpisodeComment episodeComment = episodeCommentRepository.save(
+            ofEpisodeCommentCreateRequest(episodeCommentCreateRequest, member, episode));
+
+        return episodeComment.getId();
+    }
+
+    private void checkMemberStatus(Member member) {
+        // 현재 접속한 회원의 유효성 확인
+        if (member.getStatus().equals(MemberStatus.DELETED)) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
+
+    private Episode getEpisode(Long episodeId) {
+        return episodeRepository
+            .findById(episodeId)
+            .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
+    }
+
+    private EpisodeComment ofEpisodeCommentCreateRequest(
+        EpisodeCommentCreateRequest episodeCommentCreateRequest, Member member, Episode episode) {
+        return EpisodeComment.builder()
+            .contentStatus(ContentStatus.NORMAL)
+            .creatorName(generateNewCreatorName(member, episode))
+            .content(episodeCommentCreateRequest.getContent())
+            .member(member)
+            .episode(episode)
+            .build();
+    }
+
+    private String generateNewCreatorName(Member member, Episode episode) {
+        Optional<EpisodeComment> episodeComment = episodeCommentRepository.findFirstByMemberIdAndEpisodeId(
+            member.getId(), episode.getId());
+        if (episodeComment.isPresent()) {
+            return episodeComment.get().getCreatorName();
+        }
+        return "익명 " + getDistinctMemberCount(episode.getId());
+    }
+
+    private long getDistinctMemberCount(Long episodeId) {
+        return episodeCommentRepository.countDistinctMembersByEpisode(episodeId) + 1;
+    }
+
+}

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -21,16 +21,17 @@ public class EpisodeCommentService {
     private final EpisodeRepository episodeRepository;
     private final MemberUtil memberUtil;
 
-    public EpisodeCommentService(EpisodeCommentRepository episodeCommentRepository,
-        EpisodeRepository episodeRepository,
-        MemberUtil memberUtil) {
+    public EpisodeCommentService(
+            EpisodeCommentRepository episodeCommentRepository,
+            EpisodeRepository episodeRepository,
+            MemberUtil memberUtil) {
         this.episodeCommentRepository = episodeCommentRepository;
         this.episodeRepository = episodeRepository;
         this.memberUtil = memberUtil;
     }
 
-    public Long createEpisodeComment(Long episodeId,
-        EpisodeCommentCreateRequest episodeCommentCreateRequest) {
+    public Long createEpisodeComment(
+            Long episodeId, EpisodeCommentCreateRequest episodeCommentCreateRequest) {
 
         // 회원 확인
         Member member = memberUtil.getCurrentMember();
@@ -39,8 +40,10 @@ public class EpisodeCommentService {
         // Episode 확인
         Episode episode = getEpisode(episodeId);
 
-        EpisodeComment episodeComment = episodeCommentRepository.save(
-            ofEpisodeCommentCreateRequest(episodeCommentCreateRequest, member, episode));
+        EpisodeComment episodeComment =
+                episodeCommentRepository.save(
+                        ofEpisodeCommentCreateRequest(
+                                episodeCommentCreateRequest, member, episode));
 
         return episodeComment.getId();
     }
@@ -54,24 +57,27 @@ public class EpisodeCommentService {
 
     private Episode getEpisode(Long episodeId) {
         return episodeRepository
-            .findById(episodeId)
-            .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
+                .findById(episodeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
     }
 
     private EpisodeComment ofEpisodeCommentCreateRequest(
-        EpisodeCommentCreateRequest episodeCommentCreateRequest, Member member, Episode episode) {
+            EpisodeCommentCreateRequest episodeCommentCreateRequest,
+            Member member,
+            Episode episode) {
         return EpisodeComment.builder()
-            .contentStatus(ContentStatus.NORMAL)
-            .creatorName(generateNewCreatorName(member, episode))
-            .content(episodeCommentCreateRequest.getContent())
-            .member(member)
-            .episode(episode)
-            .build();
+                .contentStatus(ContentStatus.NORMAL)
+                .creatorName(generateNewCreatorName(member, episode))
+                .content(episodeCommentCreateRequest.getContent())
+                .member(member)
+                .episode(episode)
+                .build();
     }
 
     private String generateNewCreatorName(Member member, Episode episode) {
-        Optional<EpisodeComment> episodeComment = episodeCommentRepository.findFirstByMemberIdAndEpisodeId(
-            member.getId(), episode.getId());
+        Optional<EpisodeComment> episodeComment =
+                episodeCommentRepository.findFirstByMemberIdAndEpisodeId(
+                        member.getId(), episode.getId());
         if (episodeComment.isPresent()) {
             return episodeComment.get().getCreatorName();
         }
@@ -81,5 +87,4 @@ public class EpisodeCommentService {
     private long getDistinctMemberCount(Long episodeId) {
         return episodeCommentRepository.countDistinctMembersByEpisode(episodeId) + 1;
     }
-
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -20,6 +20,8 @@ public class EpisodeCommentService {
     private final EpisodeCommentRepository episodeCommentRepository;
     private final EpisodeRepository episodeRepository;
     private final MemberUtil memberUtil;
+    private static final String EPISODE_CREATOR_NAME = "작성자";
+    private static final String PREFIX_CREATOR_NAME = "익명";
 
     public EpisodeCommentService(
             EpisodeCommentRepository episodeCommentRepository,
@@ -75,13 +77,18 @@ public class EpisodeCommentService {
     }
 
     private String generateNewCreatorName(Member member, Episode episode) {
+        if (episode.getMember().equals(member)) {
+
+            return EPISODE_CREATOR_NAME;
+        }
         Optional<EpisodeComment> episodeComment =
                 episodeCommentRepository.findFirstByMemberIdAndEpisodeId(
                         member.getId(), episode.getId());
+
         if (episodeComment.isPresent()) {
             return episodeComment.get().getCreatorName();
         }
-        return "익명 " + getDistinctMemberCount(episode.getId());
+        return PREFIX_CREATOR_NAME + getDistinctMemberCount(episode.getId());
     }
 
     private long getDistinctMemberCount(Long episodeId) {


### PR DESCRIPTION
## 💡 Issue
- #42 

## 📌 Work Description
- 에피소드 댓글을 생성하는 api를 개발했습니다. 
- 댓글 작성자의 익명 작성자명을 생성하는 기능을 개발하였습니다.

## ✅ 테스트 항목
- [x]  주어진 episodeId와 EpisodeCommentCreateRequest를 사용하여 댓글이 성공적으로 작성되는지 확인합니다.
- [x] 삭제된 회원의 댓글 작성 시도 시 예외 ErrorCode.MEMBER_NOT_FOUND인지 검증
- [x] 존재하지 않는 에피소드에 대한 댓글 작성 시도 시 ErrorCode.EPISODE_NOT_FOUND인지 확인
- [x] 댓글 내용이 비어있는 경우: 댓글 내용이 비어있는 EpisodeCommentCreateRequest를 사용하여 댓글 작성 시도 시 적절한 예외가 발생하는지 확인합니다.
- [x] 중복 댓글 작성: 동일한 회원이 동일한 에피소드에 댓글을 작성할 경우, 기존 댓글의 작성자 이름이 반환되는지 확인합니다.
- [x] 댓글 작성 시 멤버 수 증가 확인: 새로운 회원이 댓글을 작성할 때, getDistinctMemberCount 메서드가 올바르게 호출되고, 멤버 수가 증가하는지 확인합니다.

## 📝 Reference
- 

## 📚 Etc
- 
