### PR TITLE
Comment/47 에피소드 댓글 수정 삭제

### DIFF
--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -96,7 +96,7 @@ public class EpisodeController implements EpisodeControllerDocs {
 
     @DeleteMapping("/{episodeId}/comments/{episodeCommentId}")
     public ResponseEntity<Void> deleteEpisodeComment(
-        @PathVariable Long episodeId, @PathVariable Long episodeCommentId) {
+            @PathVariable Long episodeId, @PathVariable Long episodeCommentId) {
         episodeCommentService.deleteEpisodeComment(episodeId, episodeCommentId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -2,6 +2,7 @@ package com.dopamingu.be.domain.episode.controller;
 
 import com.dopamingu.be.domain.episode.controller.docs.EpisodeControllerDocs;
 import com.dopamingu.be.domain.episode.dto.EpisodeCommentCreateRequest;
+import com.dopamingu.be.domain.episode.dto.EpisodeCommentUpdateRequest;
 import com.dopamingu.be.domain.episode.dto.EpisodeCreateRequest;
 import com.dopamingu.be.domain.episode.dto.EpisodeCreateResponse;
 import com.dopamingu.be.domain.episode.dto.EpisodeDetailGetResponse;
@@ -82,5 +83,14 @@ public class EpisodeController implements EpisodeControllerDocs {
             @PathVariable Long episodeId,
             @Valid @RequestBody EpisodeCommentCreateRequest episodeCommentCreateRequest) {
         return episodeCommentService.createEpisodeComment(episodeId, episodeCommentCreateRequest);
+    }
+
+    @PatchMapping("/{episodeId}/comments/{episodeCommentId}")
+    public Long updateEpisodeComment(
+            @PathVariable Long episodeId,
+            @PathVariable Long episodeCommentId,
+            @Valid @RequestBody EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
+        return episodeCommentService.updateEpisodeComment(
+                episodeId, episodeCommentId, episodeCommentUpdateRequest);
     }
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -93,4 +93,11 @@ public class EpisodeController implements EpisodeControllerDocs {
         return episodeCommentService.updateEpisodeComment(
                 episodeId, episodeCommentId, episodeCommentUpdateRequest);
     }
+
+    @DeleteMapping("/{episodeId}/comments/{episodeCommentId}")
+    public ResponseEntity<Void> deleteEpisodeComment(
+        @PathVariable Long episodeId, @PathVariable Long episodeCommentId) {
+        episodeCommentService.deleteEpisodeComment(episodeId, episodeCommentId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/domain/EpisodeComment.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/domain/EpisodeComment.java
@@ -77,4 +77,8 @@ public class EpisodeComment extends BaseTimeEntity {
     public void updateEpisodeComment(EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
         this.content = episodeCommentUpdateRequest.getContent();
     }
+
+    public void deleteEpisodeComment() {
+        this.contentStatus = ContentStatus.DELETED;
+    }
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/domain/EpisodeComment.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/domain/EpisodeComment.java
@@ -1,6 +1,7 @@
 package com.dopamingu.be.domain.episode.domain;
 
 import com.dopamingu.be.domain.common.model.BaseTimeEntity;
+import com.dopamingu.be.domain.episode.dto.EpisodeCommentUpdateRequest;
 import com.dopamingu.be.domain.member.domain.Member;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -71,5 +72,9 @@ public class EpisodeComment extends BaseTimeEntity {
         this.parent = parent;
         this.episode = episode;
         this.member = member;
+    }
+
+    public void updateEpisodeComment(EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
+        this.content = episodeCommentUpdateRequest.getContent();
     }
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentUpdateRequest.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.dopamingu.be.domain.episode.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class EpisodeCommentUpdateRequest {
+
+    @NotBlank(message = "댓글의 내용을 입력해주세요,")
+    @Size(max = 100)
+    private String content;
+}

--- a/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
@@ -1,5 +1,6 @@
 package com.dopamingu.be.domain.episode.repository;
 
+import com.dopamingu.be.domain.episode.domain.ContentStatus;
 import com.dopamingu.be.domain.episode.domain.EpisodeComment;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,7 @@ public interface EpisodeCommentRepository extends JpaRepository<EpisodeComment, 
     @Query(
             "SELECT COUNT(DISTINCT ec.member.id) FROM EpisodeComment ec WHERE ec.episode.id = :episodeId")
     long countDistinctMembersByEpisode(@Param("episodeId") Long episodeId);
+
+    Optional<EpisodeComment> findByIdAndContentStatus(
+            Long episodeCommentId, ContentStatus contentStatus);
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -4,6 +4,7 @@ import com.dopamingu.be.domain.episode.domain.ContentStatus;
 import com.dopamingu.be.domain.episode.domain.Episode;
 import com.dopamingu.be.domain.episode.domain.EpisodeComment;
 import com.dopamingu.be.domain.episode.dto.EpisodeCommentCreateRequest;
+import com.dopamingu.be.domain.episode.dto.EpisodeCommentUpdateRequest;
 import com.dopamingu.be.domain.episode.repository.EpisodeCommentRepository;
 import com.dopamingu.be.domain.episode.repository.EpisodeRepository;
 import com.dopamingu.be.domain.global.error.exception.CustomException;
@@ -13,8 +14,10 @@ import com.dopamingu.be.domain.member.domain.Member;
 import com.dopamingu.be.domain.member.domain.MemberStatus;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class EpisodeCommentService {
 
     private final EpisodeCommentRepository episodeCommentRepository;
@@ -50,6 +53,26 @@ public class EpisodeCommentService {
         return episodeComment.getId();
     }
 
+    public Long updateEpisodeComment(
+            Long episodeId,
+            Long episodeCommentId,
+            EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
+        // 회원 확인
+        Member member = memberUtil.getCurrentMember();
+        checkMemberStatus(member);
+
+        // Episode 확인
+        Episode episode = getEpisode(episodeId);
+
+        // EpisodeComment 확인
+        EpisodeComment episodeComment = getEpisodeComment(episodeCommentId);
+
+        // 내용 변경
+        episodeComment.updateEpisodeComment(episodeCommentUpdateRequest);
+
+        return episodeComment.getId();
+    }
+
     private void checkMemberStatus(Member member) {
         // 현재 접속한 회원의 유효성 확인
         if (member.getStatus().equals(MemberStatus.DELETED)) {
@@ -61,6 +84,12 @@ public class EpisodeCommentService {
         return episodeRepository
                 .findById(episodeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
+    }
+
+    private EpisodeComment getEpisodeComment(Long episodeId) {
+        return episodeCommentRepository
+                .findByIdAndContentStatus(episodeId, ContentStatus.NORMAL)
+                .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
     }
 
     private EpisodeComment ofEpisodeCommentCreateRequest(

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -75,6 +75,23 @@ public class EpisodeCommentService {
         return episodeComment.getId();
     }
 
+    public void deleteEpisodeComment(Long episodeId, Long episodeCommentId) {
+        // 회원 확인
+        Member member = memberUtil.getCurrentMember();
+        checkMemberStatus(member);
+
+        // Episode 확인
+        Episode episode = getEpisode(episodeId);
+
+        // EpisodeComment 확인
+        EpisodeComment episodeComment = getEpisodeComment(episodeCommentId);
+
+        checkRequestorIsCreator(episodeComment, member);
+
+        // 삭제 처리
+        episodeComment.deleteEpisodeComment();
+    }
+
     private void checkMemberStatus(Member member) {
         // 현재 접속한 회원의 유효성 확인
         if (member.getStatus().equals(MemberStatus.DELETED)) {

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -67,6 +67,8 @@ public class EpisodeCommentService {
         // EpisodeComment 확인
         EpisodeComment episodeComment = getEpisodeComment(episodeCommentId);
 
+        checkRequestorIsCreator(episodeComment, member);
+
         // 내용 변경
         episodeComment.updateEpisodeComment(episodeCommentUpdateRequest);
 
@@ -90,6 +92,12 @@ public class EpisodeCommentService {
         return episodeCommentRepository
                 .findByIdAndContentStatus(episodeId, ContentStatus.NORMAL)
                 .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
+    }
+
+    private void checkRequestorIsCreator(EpisodeComment episodeComment, Member member) {
+        if (!episodeComment.getMember().equals(member)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
     }
 
     private EpisodeComment ofEpisodeCommentCreateRequest(

--- a/src/main/java/com/dopamingu/be/domain/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dopamingu/be/domain/global/error/exception/ErrorCode.java
@@ -17,6 +17,8 @@ public enum ErrorCode {
     AUTH_NOT_FOUND(HttpStatus.UNAUTHORIZED, "DP4013", "시큐리티 인증 정보를 찾을 수 없습니다."),
     MISSING_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "DP4014", "토큰 정보가 존재하지 않습니다."),
 
+    FORBIDDEN(HttpStatus.FORBIDDEN, "DP4030", "해당 작업을 할 권한이 없습니다."),
+
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "DP4040", "해당 회원을 찾을 수 없습니다."),
     EPISODE_NOT_FOUND(HttpStatus.NOT_FOUND, "DP4041", "해당 에피소드를 찾을 수 없습니다."),
     EPISODE_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "DP4042", "좋아요를 한 적 없는 에피소드입니다."),

--- a/src/main/java/com/dopamingu/be/domain/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dopamingu/be/domain/global/error/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "DP4040", "해당 회원을 찾을 수 없습니다."),
     EPISODE_NOT_FOUND(HttpStatus.NOT_FOUND, "DP4041", "해당 에피소드를 찾을 수 없습니다."),
     EPISODE_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "DP4042", "좋아요를 한 적 없는 에피소드입니다."),
+    EPISODE_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP4043", "삭제된 댓글입니다."),
 
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "DP4050", "잘못된 HTTP 메서드입니다."),
 


### PR DESCRIPTION
## 💡 Issue
- #47 

## 📌 Work Description
- 에피소드 댓글 수정, 삭제하는 API 입니다. 

## ✅ 테스트 항목
댓글 수정 (updateEpisodeComment)

- [ ] 정상적인 댓글 수정: 댓글이 성공적으로 수정되고 내용이 업데이트되는지 확인.
- [ ] 삭제된 회원의 수정 시도: 삭제된 회원 상태에서 CustomException 발생 확인.
- [ ] 존재하지 않는 에피소드 수정 시도: CustomException 발생 확인.
- [ ] 존재하지 않는 댓글 수정 시도: CustomException 발생 확인.
- [ ] 댓글 작성자가 아닌 경우 수정 시도: CustomException 발생 확인.

댓글 삭제 (deleteEpisodeComment)
- [ ] 정상적인 댓글 삭제: 댓글이 성공적으로 삭제되는지 확인.
- [ ] 삭제된 회원의 삭제 시도: CustomException 발생 확인.
- [ ] 존재하지 않는 에피소드 삭제 시도: CustomException 발생 확인.
- [ ] 존재하지 않는 댓글 삭제 시도: CustomException 발생 확인.
- [ ] 댓글 작성자가 아닌 경우 삭제 시도: CustomException 발생 확인.

## 📝 Reference
- 

## 📚 Etc
- 
