### PR TITLE
[feat] add create EpisodeSubComment

### DIFF
--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -100,4 +100,13 @@ public class EpisodeController implements EpisodeControllerDocs {
         episodeCommentService.deleteEpisodeComment(episodeId, episodeCommentId);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/{episodeId}/comments/{episodeCommentId}")
+    public Long createEpisodeSubComment(
+            @PathVariable Long episodeId,
+            @PathVariable Long episodeCommentId,
+            @Valid @RequestBody EpisodeCommentCreateRequest episodeCommentCreateRequest) {
+        return episodeCommentService.createEpisodeSubComment(
+                episodeId, episodeCommentId, episodeCommentCreateRequest);
+    }
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -92,6 +92,28 @@ public class EpisodeCommentService {
         episodeComment.deleteEpisodeComment();
     }
 
+    public Long createEpisodeSubComment(
+            Long episodeId,
+            Long episodeCommentId,
+            EpisodeCommentCreateRequest episodeCommentCreateRequest) {
+        // 회원 확인
+        Member member = memberUtil.getCurrentMember();
+        checkMemberStatus(member);
+
+        // Episode 확인
+        Episode episode = getEpisode(episodeId);
+
+        // EpisodeComment 확인
+        EpisodeComment episodeComment = getEpisodeComment(episodeCommentId);
+
+        EpisodeComment episodeSubComment =
+                episodeCommentRepository.save(
+                        buildSubComment(
+                                episodeCommentCreateRequest, member, episode, episodeComment));
+
+        return episodeSubComment.getId();
+    }
+
     private void checkMemberStatus(Member member) {
         // 현재 접속한 회원의 유효성 확인
         if (member.getStatus().equals(MemberStatus.DELETED)) {
@@ -129,6 +151,22 @@ public class EpisodeCommentService {
                 .episode(episode)
                 .build();
     }
+
+    private EpisodeComment buildSubComment(
+            EpisodeCommentCreateRequest episodeCommentCreateRequest,
+            Member member,
+            Episode episode,
+            EpisodeComment episodeComment) {
+        return EpisodeComment.builder()
+                .contentStatus(ContentStatus.NORMAL)
+                .creatorName(generateNewCreatorName(member, episode))
+                .content(episodeCommentCreateRequest.getContent())
+                .member(member)
+                .episode(episode)
+                .parent(episodeComment)
+                .build();
+    }
+    ;
 
     private String generateNewCreatorName(Member member, Episode episode) {
         if (episode.getMember().equals(member)) {


### PR DESCRIPTION
## 💡 Issue
- #51 

## 📌 Work Description

- 에피소드 대댓글 생성 기능 구현
- 부모 댓글에 대한 대댓글을 작성할 수 있는 기능 추가
- 대댓글 작성자 이름은 해당 에피소드의 댓글 작성 규칙을 따름
- 작성자 본인이면 "작성자", 아니면 "익명N" 형식으로 부여

## ✅ 테스트 항목

- [x] 정상적인 대댓글 생성이 가능한지 확인
- [x] 부모 댓글이 존재하지 않을 경우 적절한 에러 반환
- [ ] 삭제된 에피소드에 대댓글 작성 시 에러 반환
- [x] 작성자 이름이 규칙에 맞게 부여되는지 확인
- [x] 대댓글의 부모-자식 관계가 올바르게 설정되는지 확인


## 📝 Reference
- 

## 📚 Etc
- 
