### PR TITLE
Comment/55 에피소드 대댓글 수정삭제

### DIFF
--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -109,4 +109,24 @@ public class EpisodeController implements EpisodeControllerDocs {
         return episodeCommentService.createEpisodeSubComment(
                 episodeId, episodeCommentId, episodeCommentCreateRequest);
     }
+
+    @PatchMapping("/{episodeId}/comments/{episodeCommentId}/subComments/{episodeSubCommentId}")
+    public Long updateEpisodeSubComment(
+        @PathVariable Long episodeId,
+        @PathVariable Long episodeCommentId,
+        @PathVariable Long episodeSubCommentId,
+        @Valid @RequestBody EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
+        return episodeCommentService.updateEpisodeSubComment(
+            episodeId, episodeCommentId, episodeSubCommentId, episodeCommentUpdateRequest);
+    }
+
+    @DeleteMapping("/{episodeId}/comments/{episodeCommentId}/subComments/{episodeSubCommentId}")
+    public ResponseEntity<Void> deleteEpisodeSubComment(
+        @PathVariable Long episodeId,
+        @PathVariable Long episodeCommentId,
+        @PathVariable Long episodeSubCommentId) {
+        episodeCommentService.deleteEpisodeSubComment(
+            episodeId, episodeCommentId, episodeSubCommentId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -112,21 +112,21 @@ public class EpisodeController implements EpisodeControllerDocs {
 
     @PatchMapping("/{episodeId}/comments/{episodeCommentId}/subComments/{episodeSubCommentId}")
     public Long updateEpisodeSubComment(
-        @PathVariable Long episodeId,
-        @PathVariable Long episodeCommentId,
-        @PathVariable Long episodeSubCommentId,
-        @Valid @RequestBody EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
+            @PathVariable Long episodeId,
+            @PathVariable Long episodeCommentId,
+            @PathVariable Long episodeSubCommentId,
+            @Valid @RequestBody EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
         return episodeCommentService.updateEpisodeSubComment(
-            episodeId, episodeCommentId, episodeSubCommentId, episodeCommentUpdateRequest);
+                episodeId, episodeCommentId, episodeSubCommentId, episodeCommentUpdateRequest);
     }
 
     @DeleteMapping("/{episodeId}/comments/{episodeCommentId}/subComments/{episodeSubCommentId}")
     public ResponseEntity<Void> deleteEpisodeSubComment(
-        @PathVariable Long episodeId,
-        @PathVariable Long episodeCommentId,
-        @PathVariable Long episodeSubCommentId) {
+            @PathVariable Long episodeId,
+            @PathVariable Long episodeCommentId,
+            @PathVariable Long episodeSubCommentId) {
         episodeCommentService.deleteEpisodeSubComment(
-            episodeId, episodeCommentId, episodeSubCommentId);
+                episodeId, episodeCommentId, episodeSubCommentId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
@@ -13,12 +13,15 @@ public interface EpisodeCommentRepository extends JpaRepository<EpisodeComment, 
     Optional<EpisodeComment> findFirstByMemberIdAndEpisodeId(Long memberId, Long episodeId);
 
     @Query(
-        "SELECT COUNT(DISTINCT ec.member.id) FROM EpisodeComment ec WHERE ec.episode.id = :episodeId and ec.creatorName != '작성자'")
+            "SELECT COUNT(DISTINCT ec.member.id) FROM EpisodeComment ec WHERE ec.episode.id = :episodeId and ec.creatorName != '작성자'")
     long countDistinctMembersByEpisode(@Param("episodeId") Long episodeId);
 
     Optional<EpisodeComment> findByIdAndContentStatus(
             Long episodeCommentId, ContentStatus contentStatus);
 
-    Optional<EpisodeComment> findByIdAndContentStatusAndEpisodeAndParent(Long episodeSubCommentId,
-        ContentStatus contentStatus, Episode episode, EpisodeComment episodeComment);
+    Optional<EpisodeComment> findByIdAndContentStatusAndEpisodeAndParent(
+            Long episodeSubCommentId,
+            ContentStatus contentStatus,
+            Episode episode,
+            EpisodeComment episodeComment);
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
@@ -1,6 +1,7 @@
 package com.dopamingu.be.domain.episode.repository;
 
 import com.dopamingu.be.domain.episode.domain.ContentStatus;
+import com.dopamingu.be.domain.episode.domain.Episode;
 import com.dopamingu.be.domain.episode.domain.EpisodeComment;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,7 @@ public interface EpisodeCommentRepository extends JpaRepository<EpisodeComment, 
 
     Optional<EpisodeComment> findByIdAndContentStatus(
             Long episodeCommentId, ContentStatus contentStatus);
+
+    Optional<EpisodeComment> findByIdAndContentStatusAndEpisodeAndParent(Long episodeSubCommentId,
+        ContentStatus contentStatus, Episode episode, EpisodeComment episodeComment);
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -114,6 +114,52 @@ public class EpisodeCommentService {
         return episodeSubComment.getId();
     }
 
+    public Long updateEpisodeSubComment(
+        Long episodeId,
+        Long episodeCommentId,
+        Long episodeSubCommentId,
+        EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
+        // 회원 확인
+        Member member = memberUtil.getCurrentMember();
+        checkMemberStatus(member);
+
+        // Episode 확인
+        Episode episode = getEpisode(episodeId);
+
+        // EpisodeComment 확인
+        EpisodeComment episodeComment = getEpisodeComment(episodeCommentId);
+
+        // EpisodeSubComment 확인
+        EpisodeComment episodeSubComment = getEpisodeComment(episodeSubCommentId);
+
+        checkRequestorIsCreator(episodeSubComment, member);
+
+        // 내용 변경
+        episodeSubComment.updateEpisodeComment(episodeCommentUpdateRequest);
+
+        return episodeComment.getId();
+    }
+
+    public void deleteEpisodeSubComment(
+        Long episodeId, Long episodeCommentId, Long episodeSubCommentId) {
+        // 회원 확인
+        Member member = memberUtil.getCurrentMember();
+        checkMemberStatus(member);
+
+        // Episode 확인
+        Episode episode = getEpisode(episodeId);
+
+        // EpisodeComment 확인
+        EpisodeComment episodeComment = getEpisodeComment(episodeCommentId);
+
+        // EpisodeSubComment 확인
+        EpisodeComment episodeSubComment = getEpisodeComment(episodeSubCommentId);
+
+        checkRequestorIsCreator(episodeSubComment, member);
+        // 삭제 처리
+        episodeSubComment.deleteEpisodeComment();
+    }
+
     private void checkMemberStatus(Member member) {
         // 현재 접속한 회원의 유효성 확인
         if (member.getStatus().equals(MemberStatus.DELETED)) {
@@ -127,9 +173,9 @@ public class EpisodeCommentService {
                 .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
     }
 
-    private EpisodeComment getEpisodeComment(Long episodeId) {
+    private EpisodeComment getEpisodeComment(Long epicodeCommentId) {
         return episodeCommentRepository
-                .findByIdAndContentStatus(episodeId, ContentStatus.NORMAL)
+            .findByIdAndContentStatus(epicodeCommentId, ContentStatus.NORMAL)
                 .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
     }
 
@@ -166,7 +212,6 @@ public class EpisodeCommentService {
                 .parent(episodeComment)
                 .build();
     }
-    ;
 
     private String generateNewCreatorName(Member member, Episode episode) {
         if (episode.getMember().equals(member)) {

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -127,17 +127,18 @@ public class EpisodeCommentService {
         Episode episode = getEpisode(episodeId);
 
         // EpisodeComment 확인
-        EpisodeComment episodeComment = getEpisodeComment(episodeCommentId);
+        EpisodeComment episodeComment = checkEpisodeCommentId(episodeCommentId);
 
         // EpisodeSubComment 확인
-        EpisodeComment episodeSubComment = getEpisodeComment(episodeSubCommentId);
+        EpisodeComment episodeSubComment = getEpisodeSubComment(episodeSubCommentId, episode,
+            episodeComment);
 
         checkRequestorIsCreator(episodeSubComment, member);
 
         // 내용 변경
         episodeSubComment.updateEpisodeComment(episodeCommentUpdateRequest);
 
-        return episodeComment.getId();
+        return episodeSubComment.getId();
     }
 
     public void deleteEpisodeSubComment(
@@ -150,10 +151,11 @@ public class EpisodeCommentService {
         Episode episode = getEpisode(episodeId);
 
         // EpisodeComment 확인
-        EpisodeComment episodeComment = getEpisodeComment(episodeCommentId);
+        EpisodeComment episodeComment = checkEpisodeCommentId(episodeCommentId);
 
         // EpisodeSubComment 확인
-        EpisodeComment episodeSubComment = getEpisodeComment(episodeSubCommentId);
+        EpisodeComment episodeSubComment = getEpisodeSubComment(episodeSubCommentId, episode,
+            episodeComment);
 
         checkRequestorIsCreator(episodeSubComment, member);
         // 삭제 처리
@@ -177,6 +179,20 @@ public class EpisodeCommentService {
         return episodeCommentRepository
             .findByIdAndContentStatus(epicodeCommentId, ContentStatus.NORMAL)
                 .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
+    }
+
+    private EpisodeComment checkEpisodeCommentId(Long episodeCommentId) {
+        return episodeCommentRepository
+            .findById(episodeCommentId)
+            .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
+    }
+
+    private EpisodeComment getEpisodeSubComment(Long episodeSubCommentId, Episode episode,
+        EpisodeComment episodeComment) {
+        return episodeCommentRepository
+            .findByIdAndContentStatusAndEpisodeAndParent(episodeSubCommentId, ContentStatus.NORMAL,
+                episode, episodeComment)
+            .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
     }
 
     private void checkRequestorIsCreator(EpisodeComment episodeComment, Member member) {

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -115,10 +115,10 @@ public class EpisodeCommentService {
     }
 
     public Long updateEpisodeSubComment(
-        Long episodeId,
-        Long episodeCommentId,
-        Long episodeSubCommentId,
-        EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
+            Long episodeId,
+            Long episodeCommentId,
+            Long episodeSubCommentId,
+            EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
         // 회원 확인
         Member member = memberUtil.getCurrentMember();
         checkMemberStatus(member);
@@ -130,8 +130,8 @@ public class EpisodeCommentService {
         EpisodeComment episodeComment = checkEpisodeCommentId(episodeCommentId);
 
         // EpisodeSubComment 확인
-        EpisodeComment episodeSubComment = getEpisodeSubComment(episodeSubCommentId, episode,
-            episodeComment);
+        EpisodeComment episodeSubComment =
+                getEpisodeSubComment(episodeSubCommentId, episode, episodeComment);
 
         checkRequestorIsCreator(episodeSubComment, member);
 
@@ -142,7 +142,7 @@ public class EpisodeCommentService {
     }
 
     public void deleteEpisodeSubComment(
-        Long episodeId, Long episodeCommentId, Long episodeSubCommentId) {
+            Long episodeId, Long episodeCommentId, Long episodeSubCommentId) {
         // 회원 확인
         Member member = memberUtil.getCurrentMember();
         checkMemberStatus(member);
@@ -154,8 +154,8 @@ public class EpisodeCommentService {
         EpisodeComment episodeComment = checkEpisodeCommentId(episodeCommentId);
 
         // EpisodeSubComment 확인
-        EpisodeComment episodeSubComment = getEpisodeSubComment(episodeSubCommentId, episode,
-            episodeComment);
+        EpisodeComment episodeSubComment =
+                getEpisodeSubComment(episodeSubCommentId, episode, episodeComment);
 
         checkRequestorIsCreator(episodeSubComment, member);
         // 삭제 처리
@@ -177,22 +177,22 @@ public class EpisodeCommentService {
 
     private EpisodeComment getEpisodeComment(Long epicodeCommentId) {
         return episodeCommentRepository
-            .findByIdAndContentStatus(epicodeCommentId, ContentStatus.NORMAL)
+                .findByIdAndContentStatus(epicodeCommentId, ContentStatus.NORMAL)
                 .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
     }
 
     private EpisodeComment checkEpisodeCommentId(Long episodeCommentId) {
         return episodeCommentRepository
-            .findById(episodeCommentId)
-            .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
+                .findById(episodeCommentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
     }
 
-    private EpisodeComment getEpisodeSubComment(Long episodeSubCommentId, Episode episode,
-        EpisodeComment episodeComment) {
+    private EpisodeComment getEpisodeSubComment(
+            Long episodeSubCommentId, Episode episode, EpisodeComment episodeComment) {
         return episodeCommentRepository
-            .findByIdAndContentStatusAndEpisodeAndParent(episodeSubCommentId, ContentStatus.NORMAL,
-                episode, episodeComment)
-            .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
+                .findByIdAndContentStatusAndEpisodeAndParent(
+                        episodeSubCommentId, ContentStatus.NORMAL, episode, episodeComment)
+                .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
     }
 
     private void checkRequestorIsCreator(EpisodeComment episodeComment, Member member) {


### PR DESCRIPTION
## 💡 Issue
- #55 

## 📌 Work Description

- 대댓글 수정 및 삭제 기능 구현
- 대댓글 작성자만 수정/삭제가 가능하도록 권한 체크
- 삭제된 댓글은 ContentStatus를 DELETED로 변경하여 소프트 삭제 처리

✅ 테스트 항목
### updateEpisodeSubComment

- [x] 존재하지 않는 대댓글 수정 시도 시 예외 발생
- [x] 작성자가 아닌 사용자가 대댓글 수정 시도 시 권한 예외 발생
- [x] 탈퇴한 회원이 대댓글 수정 시도 시 예외 발생
- [x] 정상적인 대댓글 수정 성공 시 수정된 내용 반영

### deleteEpisodeSubComment

- [x] 존재하지 않는 대댓글 삭제 시도 시 예외 발생
- [x] 작성자가 아닌 사용자가 대댓글 삭제 시도 시 권한 예외 발생
- [x] 탈퇴한 회원이 대댓글 삭제 시도 시 예외 발생
- [x] 정상적인 대댓글 삭제 성공 시 ContentStatus가 DELETED로 변경

## 📝 Reference
- 

## 📚 Etc
- 
