### PR TITLE
59 댓글 대댓글 api 통합

### DIFF
--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -35,12 +35,14 @@ public class EpisodeController implements EpisodeControllerDocs {
     private final EpisodeLikeService episodeLikeService;
     private final EpisodeCommentService episodeCommentService;
 
+    @Override
     @PostMapping
     public EpisodeCreateResponse createEpisode(
             @Valid @RequestBody EpisodeCreateRequest episodeCreateRequest) {
         return episodeService.createEpisode(episodeCreateRequest);
     }
 
+    @Override
     @PatchMapping("/{episodeId}")
     public EpisodeUpdateResponse updateEpisode(
             @PathVariable Long episodeId,
@@ -48,11 +50,13 @@ public class EpisodeController implements EpisodeControllerDocs {
         return episodeService.updateEpisode(episodeUpdateRequest, episodeId);
     }
 
+    @Override
     @DeleteMapping("/{episodeId}")
     public Long deleteEpisode(@PathVariable Long episodeId) {
         return episodeService.deleteEpisode(episodeId);
     }
 
+    @Override
     @GetMapping("")
     public Slice<EpisodeListGetResponse> getEpisodeList(
             @RequestParam(defaultValue = "1") int page,
@@ -62,22 +66,26 @@ public class EpisodeController implements EpisodeControllerDocs {
         return episodeService.getEpisodeList(page, size, sortBy, isAsc);
     }
 
+    @Override
     @GetMapping("/{episodeId}")
     public EpisodeDetailGetResponse getEpisodeDetail(@PathVariable Long episodeId) {
         return episodeService.getEpisodeDetail(episodeId);
     }
 
+    @Override
     @PostMapping("/{episodeId}/like")
     public Long likeEpisode(@PathVariable Long episodeId) {
         return episodeLikeService.likeEpisode(episodeId);
     }
 
+    @Override
     @PostMapping("/{episodeId}/unlike")
     public ResponseEntity<Void> unlikeEpisode(@PathVariable Long episodeId) {
         episodeLikeService.unlikeEpisode(episodeId);
         return ResponseEntity.noContent().build();
     }
 
+    @Override
     @PostMapping("/{episodeId}/comments")
     public Long createEpisodeComment(
             @PathVariable Long episodeId,
@@ -85,6 +93,7 @@ public class EpisodeController implements EpisodeControllerDocs {
         return episodeCommentService.createEpisodeComment(episodeId, episodeCommentCreateRequest);
     }
 
+    @Override
     @PatchMapping("/{episodeId}/comments/{episodeCommentId}")
     public Long updateEpisodeComment(
             @PathVariable Long episodeId,
@@ -94,6 +103,7 @@ public class EpisodeController implements EpisodeControllerDocs {
                 episodeId, episodeCommentId, episodeCommentUpdateRequest);
     }
 
+    @Override
     @DeleteMapping("/{episodeId}/comments/{episodeCommentId}")
     public ResponseEntity<Void> deleteEpisodeComment(
             @PathVariable Long episodeId, @PathVariable Long episodeCommentId) {

--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -100,16 +100,5 @@ public class EpisodeController implements EpisodeControllerDocs {
         episodeCommentService.deleteEpisodeComment(episodeId, episodeCommentId);
         return ResponseEntity.noContent().build();
     }
-
-
-
-    @DeleteMapping("/{episodeId}/comments/{episodeCommentId}/subComments/{episodeSubCommentId}")
-    public ResponseEntity<Void> deleteEpisodeSubComment(
-            @PathVariable Long episodeId,
-            @PathVariable Long episodeCommentId,
-            @PathVariable Long episodeSubCommentId) {
-        episodeCommentService.deleteEpisodeSubComment(
-                episodeId, episodeCommentId, episodeSubCommentId);
-        return ResponseEntity.noContent().build();
-    }
 }
+

--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -101,4 +101,3 @@ public class EpisodeController implements EpisodeControllerDocs {
         return ResponseEntity.noContent().build();
     }
 }
-

--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -102,15 +102,6 @@ public class EpisodeController implements EpisodeControllerDocs {
     }
 
 
-    @PatchMapping("/{episodeId}/comments/{episodeCommentId}/subComments/{episodeSubCommentId}")
-    public Long updateEpisodeSubComment(
-            @PathVariable Long episodeId,
-            @PathVariable Long episodeCommentId,
-            @PathVariable Long episodeSubCommentId,
-            @Valid @RequestBody EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
-        return episodeCommentService.updateEpisodeSubComment(
-                episodeId, episodeCommentId, episodeSubCommentId, episodeCommentUpdateRequest);
-    }
 
     @DeleteMapping("/{episodeId}/comments/{episodeCommentId}/subComments/{episodeSubCommentId}")
     public ResponseEntity<Void> deleteEpisodeSubComment(

--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -101,14 +101,6 @@ public class EpisodeController implements EpisodeControllerDocs {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/{episodeId}/comments/{episodeCommentId}")
-    public Long createEpisodeSubComment(
-            @PathVariable Long episodeId,
-            @PathVariable Long episodeCommentId,
-            @Valid @RequestBody EpisodeCommentCreateRequest episodeCommentCreateRequest) {
-        return episodeCommentService.createEpisodeSubComment(
-                episodeId, episodeCommentId, episodeCommentCreateRequest);
-    }
 
     @PatchMapping("/{episodeId}/comments/{episodeCommentId}/subComments/{episodeSubCommentId}")
     public Long updateEpisodeSubComment(

--- a/src/main/java/com/dopamingu/be/domain/episode/controller/docs/EpisodeControllerDocs.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/docs/EpisodeControllerDocs.java
@@ -1,5 +1,7 @@
 package com.dopamingu.be.domain.episode.controller.docs;
 
+import com.dopamingu.be.domain.episode.dto.EpisodeCommentCreateRequest;
+import com.dopamingu.be.domain.episode.dto.EpisodeCommentUpdateRequest;
 import com.dopamingu.be.domain.episode.dto.EpisodeCreateRequest;
 import com.dopamingu.be.domain.episode.dto.EpisodeCreateResponse;
 import com.dopamingu.be.domain.episode.dto.EpisodeDetailGetResponse;
@@ -7,10 +9,15 @@ import com.dopamingu.be.domain.episode.dto.EpisodeListGetResponse;
 import com.dopamingu.be.domain.episode.dto.EpisodeUpdateRequest;
 import com.dopamingu.be.domain.episode.dto.EpisodeUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -18,15 +25,18 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface EpisodeControllerDocs {
 
     @Operation(summary = "에피소드 등록", description = "에피소드를 등록하는 API")
-    public EpisodeCreateResponse createEpisode(EpisodeCreateRequest episodeCreateRequest);
+    public EpisodeCreateResponse createEpisode(
+        @Parameter(description = "에피소드 생성 요청 정보") @Valid @RequestBody
+        EpisodeCreateRequest episodeCreateRequest);
 
     @Operation(summary = "에피소드 수정", description = "에피소드를 수정하는 API")
     public EpisodeUpdateResponse updateEpisode(
-            @PathVariable Long episodeId,
+        @Parameter(name = "episodeId", description = "에피소드 ID") @PathVariable Long episodeId,
             @Valid @RequestBody EpisodeUpdateRequest episodeUpdateRequest);
 
     @Operation(summary = "에피소드 삭제", description = "에피소드를 삭제하는 API")
-    public Long deleteEpisode(@PathVariable Long episodeId);
+    public Long deleteEpisode(
+        @Parameter(name = "episodeId", description = "에피소드 ID") @PathVariable Long episodeId);
 
     @Operation(summary = "에피소드 조회", description = "에피소드를 조회하는 API")
     public Slice<EpisodeListGetResponse> getEpisodeList(
@@ -36,8 +46,36 @@ public interface EpisodeControllerDocs {
             @RequestParam(required = false, defaultValue = "false") boolean isAsc);
 
     @Operation(summary = "에피소드 상세 조회", description = "에피소드 개별 조회하는 API")
-    public EpisodeDetailGetResponse getEpisodeDetail(@PathVariable Long episodeId);
+    public EpisodeDetailGetResponse getEpisodeDetail(
+        @Parameter(name = "episodeId", description = "에피소드 ID") @PathVariable Long episodeId);
 
     @Operation(summary = "에피소드 좋아요", description = "에피소드를 좋아요 등록하는 API")
-    public Long likeEpisode(@PathVariable Long episodeId);
+    public Long likeEpisode(
+        @Parameter(name = "episodeId", description = "에피소드 ID") @PathVariable Long episodeId);
+
+    @Operation(summary = "에피소드 좋아요 해제", description = "특정 에피소드의 좋아요를 해제합니다.")
+    @PostMapping("/{episodeId}/unlike")
+    public ResponseEntity<Void> unlikeEpisode(
+        @Parameter(name = "episodeId", description = "에피소드 ID") @PathVariable Long episodeId);
+
+    @Operation(summary = "에피소드 댓글 생성", description = "특정 에피소드에 댓글을 생성합니다.")
+    @PostMapping("/{episodeId}/comments")
+    Long createEpisodeComment(
+        @Parameter(name = "episodeId", description = "에피소드 ID") @PathVariable Long episodeId,
+        @Valid @RequestBody EpisodeCommentCreateRequest episodeCommentCreateRequest);
+
+    @Operation(summary = "에피소드 댓글 수정", description = "특정 에피소드에 이미 존재하는 댓글을 수정합니다.")
+    @PatchMapping("/{episodeId}/comments/{episodeCommentId}")
+    Long updateEpisodeComment(
+        @Parameter(name = "episodeId", description = "에피소드 ID") @PathVariable Long episodeId,
+        @Parameter(name = "episodeCommentId", description = "에피소드 댓글 ID") @PathVariable
+        Long episodeCommentId,
+        @Valid @RequestBody EpisodeCommentUpdateRequest episodeCommentUpdateRequest);
+
+    @Operation(summary = "에피소드 댓글 삭제", description = "특정 에피소드에 이미 존재하는 댓글을 삭제합니다.")
+    @DeleteMapping("/{episodeId}/comments/{episodeCommentId}")
+    ResponseEntity<Void> deleteEpisodeComment(
+        @Parameter(name = "episodeId", description = "에피소드 ID") @PathVariable Long episodeId,
+        @Parameter(name = "episodeCommentId", description = "에피소드 댓글 ID") @PathVariable
+        Long episodeCommentId);
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/domain/EpisodeComment.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/domain/EpisodeComment.java
@@ -74,7 +74,7 @@ public class EpisodeComment extends BaseTimeEntity {
         this.member = member;
     }
 
-    public void updateEpisodeComment(EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
+    public void updateCommentContent(EpisodeCommentUpdateRequest episodeCommentUpdateRequest) {
         this.content = episodeCommentUpdateRequest.getContent();
     }
 

--- a/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentCreateRequest.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentCreateRequest.java
@@ -1,5 +1,6 @@
 package com.dopamingu.be.domain.episode.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -7,9 +8,11 @@ import lombok.Getter;
 @Getter
 public class EpisodeCommentCreateRequest {
 
+    @Schema(description = "댓글 내용", example = "정말 재미있는 에피소드네요!")
     @NotBlank(message = "댓글의 내용을 입력해주세요,")
     @Size(max = 100)
     private String content;
 
+    @Schema(description = "부모 댓글 ID. 대댓글일 경우 설정하고, 없으면 null로 넣어주세요.", example = "null")
     private Long parentId;
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentCreateRequest.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentCreateRequest.java
@@ -10,4 +10,6 @@ public class EpisodeCommentCreateRequest {
     @NotBlank(message = "댓글의 내용을 입력해주세요,")
     @Size(max = 100)
     private String content;
+
+    private Long parentId;
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentUpdateRequest.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentUpdateRequest.java
@@ -10,4 +10,6 @@ public class EpisodeCommentUpdateRequest {
     @NotBlank(message = "댓글의 내용을 입력해주세요,")
     @Size(max = 100)
     private String content;
+
+    private Long parentId;
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentUpdateRequest.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentUpdateRequest.java
@@ -10,6 +10,4 @@ public class EpisodeCommentUpdateRequest {
     @NotBlank(message = "댓글의 내용을 입력해주세요,")
     @Size(max = 100)
     private String content;
-
-    private Long parentId;
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentUpdateRequest.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.dopamingu.be.domain.episode.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -7,6 +8,7 @@ import lombok.Getter;
 @Getter
 public class EpisodeCommentUpdateRequest {
 
+    @Schema(description = "댓글 내용", example = "정말 재미있는 에피소드네요!")
     @NotBlank(message = "댓글의 내용을 입력해주세요,")
     @Size(max = 100)
     private String content;

--- a/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCreateRequest.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCreateRequest.java
@@ -1,6 +1,7 @@
 package com.dopamingu.be.domain.episode.dto;
 
 import com.dopamingu.be.domain.episode.domain.EpisodeTheme;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.List;
@@ -13,16 +14,28 @@ public class EpisodeCreateRequest {
     @Size(max = 100)
     private String episodeName;
 
+    @Schema(description = "Episode 테마 선택", example = "FLIRTING")
     private EpisodeTheme episodeTheme;
 
     @NotBlank(message = "내용을 입력해주세요,")
     @Size(max = 500)
     private String content;
 
+    @Schema(description = "썸네일 이미지 url")
     private String thumbnailUrl;
+
+    @Schema(description = "이미지 url 전체 리스트")
     private List<String> imageUrlList;
+
+    @Schema(description = "키워드 검색시 키워드로 나오는 주소", example = "설빙 홍대입구역점")
     private String addressKeyword;
+
+    @Schema(description = "주소 전체", example = "서울 마포구 홍익로6길 15 상주빌딩 2층")
     private String address;
+
+    @Schema(description = "위도", example = "37.566826")
     private Double x;
+
+    @Schema(description = "경도", example = "126.9786567")
     private Double y;
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeUpdateRequest.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.dopamingu.be.domain.episode.dto;
 
 import com.dopamingu.be.domain.episode.domain.EpisodeTheme;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.List;
@@ -13,16 +14,28 @@ public class EpisodeUpdateRequest {
     @Size(max = 100)
     private String episodeName;
 
+    @Schema(description = "Episode 테마 선택", example = "FLIRTING")
     private EpisodeTheme episodeTheme;
 
     @NotBlank(message = "내용을 입력해주세요,")
     @Size(max = 500)
     private String content;
 
+    @Schema(description = "썸네일 이미지 url")
     private String thumbnailUrl;
+
+    @Schema(description = "이미지 url 전체 리스트")
     private List<String> imageUrlList;
+
+    @Schema(description = "키워드 검색시 키워드로 나오는 주소", example = "설빙 홍대입구역점")
     private String addressKeyword;
+
+    @Schema(description = "주소 전체", example = "서울 마포구 홍익로6길 15 상주빌딩 2층")
     private String address;
+
+    @Schema(description = "위도", example = "37.566826")
     private Double x;
+
+    @Schema(description = "경도", example = "126.9786567")
     private Double y;
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -48,14 +48,13 @@ public class EpisodeCommentService {
         // ParentComment 확인
         EpisodeComment parentComment = null;
         if (episodeCommentCreateRequest.getParentId() != null) {
-            parentComment = getValidParentComment(
-                episodeCommentCreateRequest.getParentId());
+            parentComment = getValidParentComment(episodeCommentCreateRequest.getParentId());
         }
 
         EpisodeComment episodeComment =
                 episodeCommentRepository.save(
                         ofEpisodeCommentCreateRequest(
-                            episodeCommentCreateRequest, member, episode, parentComment));
+                                episodeCommentCreateRequest, member, episode, parentComment));
 
         return episodeComment.getId();
     }
@@ -68,8 +67,8 @@ public class EpisodeCommentService {
         Member member = memberUtil.getCurrentMember();
         checkMemberStatus(member);
 
-        EpisodeComment episodeComment = getEpisodeCommentForUpdate(episodeId, episodeCommentId,
-            member);
+        EpisodeComment episodeComment =
+                getEpisodeCommentForUpdate(episodeId, episodeCommentId, member);
         episodeComment.updateCommentContent(episodeCommentUpdateRequest);
 
         return episodeCommentId;
@@ -81,8 +80,8 @@ public class EpisodeCommentService {
         checkMemberStatus(member);
 
         // Episode 확인
-        EpisodeComment episodeComment = getEpisodeCommentForUpdate(episodeId, episodeCommentId,
-            member);
+        EpisodeComment episodeComment =
+                getEpisodeCommentForUpdate(episodeId, episodeCommentId, member);
 
         // 삭제 처리
         episodeComment.deleteEpisodeComment();
@@ -92,14 +91,14 @@ public class EpisodeCommentService {
             EpisodeCommentCreateRequest episodeCommentCreateRequest,
             Member member,
             Episode episode,
-        EpisodeComment parentComment) {
+            EpisodeComment parentComment) {
         return EpisodeComment.builder()
                 .contentStatus(ContentStatus.NORMAL)
                 .creatorName(generateNewCreatorName(member, episode))
                 .content(episodeCommentCreateRequest.getContent())
                 .member(member)
                 .episode(episode)
-            .parent(parentComment)
+                .parent(parentComment)
                 .build();
     }
 
@@ -123,8 +122,7 @@ public class EpisodeCommentService {
     }
 
     /**
-     * ----------------------------------------------
-     * 아래부터는 중복되는 검증 로직을 모아둔 private 메서드들
+     * ---------------------------------------------- 아래부터는 중복되는 검증 로직을 모아둔 private 메서드들
      * ----------------------------------------------
      */
     private void checkMemberStatus(Member member) {
@@ -135,31 +133,29 @@ public class EpisodeCommentService {
     }
 
     private Episode getValidEpisode(Long episodeId) {
-        return episodeRepository.findById(episodeId)
-            .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
+        return episodeRepository
+                .findById(episodeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
     }
 
     private EpisodeComment getValidParentComment(Long episodeCommentId) {
-        return episodeCommentRepository.findById(episodeCommentId)
-            .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
+        return episodeCommentRepository
+                .findById(episodeCommentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
     }
 
     /**
-     * 댓글 수정/삭제 시 필요한 "공통 검증"을 담당하는 메서드
-     * - episodeId로 Episode를 찾고
-     * - commentId로 댓글을 찾은 뒤
-     * - 댓글이 해당 episode에 속해 있는지
-     * - 이미 삭제(status=DELETED)된 댓글인지
-     * - 작성자(writer)와 현재 사용자와 동일한지
+     * 댓글 수정/삭제 시 필요한 "공통 검증"을 담당하는 메서드 - episodeId로 Episode를 찾고 - commentId로 댓글을 찾은 뒤 - 댓글이 해당
+     * episode에 속해 있는지 - 이미 삭제(status=DELETED)된 댓글인지 - 작성자(writer)와 현재 사용자와 동일한지
      */
-
-    private EpisodeComment getEpisodeCommentForUpdate(Long episodeId, Long commentId,
-        Member creator) {
+    private EpisodeComment getEpisodeCommentForUpdate(
+            Long episodeId, Long commentId, Member creator) {
         // (1) 댓글 조회
-        EpisodeComment comment = episodeCommentRepository.findById(commentId)
-            .orElseThrow(() -> new CustomException(
-                ErrorCode.EPISODE_COMMENT_NOT_FOUND
-            ));
+        EpisodeComment comment =
+                episodeCommentRepository
+                        .findById(commentId)
+                        .orElseThrow(
+                                () -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
 
         // (2) 에피소드 일치 여부
         if (!comment.getEpisode().getId().equals(episodeId)) {
@@ -173,7 +169,6 @@ public class EpisodeCommentService {
         checkRequestorIsCreator(comment, creator);
 
         return comment;
-
     }
 
     private void checkRequestorIsCreator(EpisodeComment episodeComment, Member member) {

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -45,6 +45,21 @@ public class EpisodeCommentService {
         // Episode 확인
         Episode episode = getEpisode(episodeId);
 
+        // 댓글인지 대댓글인지 확인
+        Long parentId = episodeCommentCreateRequest.getParentId();
+        if (parentId != null) {
+            // EpisodeComment 확인
+            EpisodeComment episodeComment = checkEpisodeCommentId(parentId);
+
+            EpisodeComment episodeSubComment =
+                episodeCommentRepository.save(
+                    buildSubComment(
+                        episodeCommentCreateRequest, member, episode, episodeComment));
+
+            return episodeSubComment.getId();
+
+        }
+
         EpisodeComment episodeComment =
                 episodeCommentRepository.save(
                         ofEpisodeCommentCreateRequest(
@@ -90,28 +105,6 @@ public class EpisodeCommentService {
 
         // 삭제 처리
         episodeComment.deleteEpisodeComment();
-    }
-
-    public Long createEpisodeSubComment(
-            Long episodeId,
-            Long episodeCommentId,
-            EpisodeCommentCreateRequest episodeCommentCreateRequest) {
-        // 회원 확인
-        Member member = memberUtil.getCurrentMember();
-        checkMemberStatus(member);
-
-        // Episode 확인
-        Episode episode = getEpisode(episodeId);
-
-        // EpisodeComment 확인
-        EpisodeComment episodeComment = getEpisodeComment(episodeCommentId);
-
-        EpisodeComment episodeSubComment =
-                episodeCommentRepository.save(
-                        buildSubComment(
-                                episodeCommentCreateRequest, member, episode, episodeComment));
-
-        return episodeSubComment.getId();
     }
 
     public Long updateEpisodeSubComment(

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -43,27 +43,19 @@ public class EpisodeCommentService {
         checkMemberStatus(member);
 
         // Episode 확인
-        Episode episode = getEpisode(episodeId);
+        Episode episode = getValidEpisode(episodeId);
 
-        // 댓글인지 대댓글인지 확인
-        Long parentId = episodeCommentCreateRequest.getParentId();
-        if (parentId != null) {
-            // EpisodeComment 확인
-            EpisodeComment episodeComment = checkEpisodeCommentId(parentId);
-
-            EpisodeComment episodeSubComment =
-                episodeCommentRepository.save(
-                    buildSubComment(
-                        episodeCommentCreateRequest, member, episode, episodeComment));
-
-            return episodeSubComment.getId();
-
+        // ParentComment 확인
+        EpisodeComment parentComment = null;
+        if (episodeCommentCreateRequest.getParentId() != null) {
+            parentComment = getValidParentComment(
+                episodeCommentCreateRequest.getParentId());
         }
 
         EpisodeComment episodeComment =
                 episodeCommentRepository.save(
                         ofEpisodeCommentCreateRequest(
-                                episodeCommentCreateRequest, member, episode));
+                            episodeCommentCreateRequest, member, episode, parentComment));
 
         return episodeComment.getId();
     }
@@ -76,14 +68,11 @@ public class EpisodeCommentService {
         Member member = memberUtil.getCurrentMember();
         checkMemberStatus(member);
 
-        // Episode 확인
-        Episode episode = getEpisode(episodeId);
+        EpisodeComment episodeComment = getEpisodeCommentForUpdate(episodeId, episodeCommentId,
+            member);
+        episodeComment.updateCommentContent(episodeCommentUpdateRequest);
 
-        if (isSubComment(episodeCommentUpdateRequest)) {
-            return updateSubComment(episodeCommentId, episodeCommentUpdateRequest, episode, member);
-        }
-
-        return updateMainComment(episodeCommentId, episodeCommentUpdateRequest, member);
+        return episodeCommentId;
     }
 
     public void deleteEpisodeComment(Long episodeId, Long episodeCommentId) {
@@ -92,138 +81,25 @@ public class EpisodeCommentService {
         checkMemberStatus(member);
 
         // Episode 확인
-        Episode episode = getEpisode(episodeId);
-
-        // EpisodeComment 확인
-        EpisodeComment episodeComment = getEpisodeComment(episodeCommentId);
-
-        checkRequestorIsCreator(episodeComment, member);
+        EpisodeComment episodeComment = getEpisodeCommentForUpdate(episodeId, episodeCommentId,
+            member);
 
         // 삭제 처리
         episodeComment.deleteEpisodeComment();
     }
 
-
-    public void deleteEpisodeSubComment(
-            Long episodeId, Long episodeCommentId, Long episodeSubCommentId) {
-        // 회원 확인
-        Member member = memberUtil.getCurrentMember();
-        checkMemberStatus(member);
-
-        // Episode 확인
-        Episode episode = getEpisode(episodeId);
-
-        // EpisodeComment 확인
-        EpisodeComment episodeComment = checkEpisodeCommentId(episodeCommentId);
-
-        // EpisodeSubComment 확인
-        EpisodeComment episodeSubComment =
-                getEpisodeSubComment(episodeSubCommentId, episode, episodeComment);
-
-        checkRequestorIsCreator(episodeSubComment, member);
-        // 삭제 처리
-        episodeSubComment.deleteEpisodeComment();
-    }
-
-    private void checkMemberStatus(Member member) {
-        // 현재 접속한 회원의 유효성 확인
-        if (member.getStatus().equals(MemberStatus.DELETED)) {
-            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
-        }
-    }
-
-    private Episode getEpisode(Long episodeId) {
-        return episodeRepository
-                .findById(episodeId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
-    }
-
-    private EpisodeComment getEpisodeComment(Long epicodeCommentId) {
-        return episodeCommentRepository
-                .findByIdAndContentStatus(epicodeCommentId, ContentStatus.NORMAL)
-                .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
-    }
-
-    private EpisodeComment checkEpisodeCommentId(Long episodeCommentId) {
-        return episodeCommentRepository
-                .findById(episodeCommentId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
-    }
-
-    private boolean isSubComment(EpisodeCommentUpdateRequest updateRequest) {
-        return updateRequest.getParentId() != null;
-    }
-
-
-    private Long updateSubComment(Long episodeCommentId,
-        EpisodeCommentUpdateRequest episodeCommentUpdateRequest, Episode episode, Member member) {
-        // EpisodeComment 확인
-        EpisodeComment episodeComment = checkEpisodeCommentId(
-            episodeCommentUpdateRequest.getParentId());
-
-        // EpisodeSubComment 확인
-        EpisodeComment episodeSubComment =
-            getEpisodeSubComment(episodeCommentId, episode, episodeComment);
-
-        checkRequestorIsCreator(episodeSubComment, member);
-
-        // 내용 변경
-        episodeSubComment.updateCommentContent(episodeCommentUpdateRequest);
-        return episodeCommentId;
-    }
-
-    private EpisodeComment getEpisodeSubComment(
-            Long episodeSubCommentId, Episode episode, EpisodeComment episodeComment) {
-        return episodeCommentRepository
-                .findByIdAndContentStatusAndEpisodeAndParent(
-                        episodeSubCommentId, ContentStatus.NORMAL, episode, episodeComment)
-                .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_COMMENT_NOT_FOUND));
-    }
-
-    private Long updateMainComment(Long episodeCommentId,
-        EpisodeCommentUpdateRequest episodeCommentUpdateRequest, Member member) {
-        // EpisodeComment 확인
-        EpisodeComment episodeComment = getEpisodeComment(episodeCommentId);
-        checkRequestorIsCreator(episodeComment, member);
-
-        // 내용 변경
-        episodeComment.updateCommentContent(episodeCommentUpdateRequest);
-
-        return episodeComment.getId();
-    }
-
-
-    private void checkRequestorIsCreator(EpisodeComment episodeComment, Member member) {
-        if (!episodeComment.getMember().equals(member)) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
-    }
-
     private EpisodeComment ofEpisodeCommentCreateRequest(
             EpisodeCommentCreateRequest episodeCommentCreateRequest,
             Member member,
-            Episode episode) {
-        return EpisodeComment.builder()
-                .contentStatus(ContentStatus.NORMAL)
-                .creatorName(generateNewCreatorName(member, episode))
-                .content(episodeCommentCreateRequest.getContent())
-                .member(member)
-                .episode(episode)
-                .build();
-    }
-
-    private EpisodeComment buildSubComment(
-            EpisodeCommentCreateRequest episodeCommentCreateRequest,
-            Member member,
             Episode episode,
-            EpisodeComment episodeComment) {
+        EpisodeComment parentComment) {
         return EpisodeComment.builder()
                 .contentStatus(ContentStatus.NORMAL)
                 .creatorName(generateNewCreatorName(member, episode))
                 .content(episodeCommentCreateRequest.getContent())
                 .member(member)
                 .episode(episode)
-                .parent(episodeComment)
+            .parent(parentComment)
                 .build();
     }
 
@@ -244,5 +120,65 @@ public class EpisodeCommentService {
 
     private long getDistinctMemberCount(Long episodeId) {
         return episodeCommentRepository.countDistinctMembersByEpisode(episodeId) + 1;
+    }
+
+    /**
+     * ----------------------------------------------
+     * 아래부터는 중복되는 검증 로직을 모아둔 private 메서드들
+     * ----------------------------------------------
+     */
+    private void checkMemberStatus(Member member) {
+        // 현재 접속한 회원의 유효성 확인
+        if (member.getStatus().equals(MemberStatus.DELETED)) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
+
+    private Episode getValidEpisode(Long episodeId) {
+        return episodeRepository.findById(episodeId)
+            .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
+    }
+
+    private EpisodeComment getValidParentComment(Long episodeCommentId) {
+        return episodeCommentRepository.findById(episodeCommentId)
+            .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
+    }
+
+    /**
+     * 댓글 수정/삭제 시 필요한 "공통 검증"을 담당하는 메서드
+     * - episodeId로 Episode를 찾고
+     * - commentId로 댓글을 찾은 뒤
+     * - 댓글이 해당 episode에 속해 있는지
+     * - 이미 삭제(status=DELETED)된 댓글인지
+     * - 작성자(writer)와 현재 사용자와 동일한지
+     */
+
+    private EpisodeComment getEpisodeCommentForUpdate(Long episodeId, Long commentId,
+        Member creator) {
+        // (1) 댓글 조회
+        EpisodeComment comment = episodeCommentRepository.findById(commentId)
+            .orElseThrow(() -> new CustomException(
+                ErrorCode.EPISODE_COMMENT_NOT_FOUND
+            ));
+
+        // (2) 에피소드 일치 여부
+        if (!comment.getEpisode().getId().equals(episodeId)) {
+            throw new CustomException(ErrorCode.EPISODE_COMMENT_RELATION_NOT_FOUND);
+        }
+        // (3) 상태 확인
+        if (comment.getContentStatus() == ContentStatus.DELETED) {
+            throw new CustomException(ErrorCode.RESOURCE_DELETED);
+        }
+        // (4) 작성자와 수정/삭제자와 일치 확인
+        checkRequestorIsCreator(comment, creator);
+
+        return comment;
+
+    }
+
+    private void checkRequestorIsCreator(EpisodeComment episodeComment, Member member) {
+        if (!episodeComment.getMember().equals(member)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/com/dopamingu/be/domain/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dopamingu/be/domain/global/error/exception/ErrorCode.java
@@ -23,6 +23,8 @@ public enum ErrorCode {
     EPISODE_NOT_FOUND(HttpStatus.NOT_FOUND, "DP4041", "해당 에피소드를 찾을 수 없습니다."),
     EPISODE_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "DP4042", "좋아요를 한 적 없는 에피소드입니다."),
     EPISODE_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP4043", "존재하지 않는 댓글입니다."),
+    EPISODE_COMMENT_RELATION_NOT_FOUND(HttpStatus.NOT_FOUND, "DP404", "에피소드에 속한 댓글이 아닙니다."),
+    RESOURCE_DELETED(HttpStatus.NOT_FOUND, "DP405", "삭제된 자원입니다."),
 
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "DP4050", "잘못된 HTTP 메서드입니다."),
 


### PR DESCRIPTION
## 💡 Issue
- #59 

## 📌 Work Description
- 댓글과 대댓글의 CUD(Create, Update, Delete) 로직을 하나의 엔드포인트로 통합
- 기존의 분리되어 있던 댓글/대댓글 API를 /episodes/{episode_id}/comments/{comment_id} 형태로 단일화
- 댓글 생성 시 parentId 유무로 댓글/대댓글 구분
- 공통 검증 로직을 CommentValidator로 통합하여 코드 중복 제거

## ✅ 테스트 항목
### 댓글 생성
- [x] parentId가 없는 경우 일반 댓글 생성
- [x] parentId가 있는 경우 대댓글 생성

### 댓글 수정
- [x] 일반 댓글 수정
- [x] 대댓글 수정
- [x] 요청자 작성자가 다를 경우 예외처리 
- [x] 에피소드와 댓글/대댓글의 연관관계가 없을 경우 예외 처리

### 댓글 삭제
- [x] 일반 댓글 삭제
- [x] 대댓글 삭제
- [x] 요청자 작성자가 다를 경우 예외처리 

## 📝 Reference
- 

## 📚 Etc
- 
