### PR TITLE
Comment/50 에피소드 댓글 조회

### DIFF
--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -128,6 +128,7 @@ public class EpisodeController implements EpisodeControllerDocs {
         return ResponseEntity.noContent().build();
     }
 
+    @Override
     @GetMapping("/{episodeId}/comments")
     public Slice<EpisodeCommentListResponse> getEpisodeCommentList(
             @PathVariable Long episodeId,

--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -2,6 +2,7 @@ package com.dopamingu.be.domain.episode.controller;
 
 import com.dopamingu.be.domain.episode.controller.docs.EpisodeControllerDocs;
 import com.dopamingu.be.domain.episode.dto.EpisodeCommentCreateRequest;
+import com.dopamingu.be.domain.episode.dto.EpisodeCommentListResponse;
 import com.dopamingu.be.domain.episode.dto.EpisodeCommentUpdateRequest;
 import com.dopamingu.be.domain.episode.dto.EpisodeCreateRequest;
 import com.dopamingu.be.domain.episode.dto.EpisodeCreateResponse;
@@ -125,5 +126,15 @@ public class EpisodeController implements EpisodeControllerDocs {
             @PathVariable Long episodeId, @PathVariable Long episodeCommentId) {
         episodeCommentLikeService.unlikeEpisodeComment(episodeId, episodeCommentId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{episodeId}/comments")
+    public Slice<EpisodeCommentListResponse> getEpisodeCommentList(
+        @PathVariable Long episodeId,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "10") int size,
+        @RequestParam(required = false, defaultValue = "createdAt") String sortBy,
+        @RequestParam(required = false, defaultValue = "false") boolean isAsc) {
+        return episodeCommentService.getEpisodeCommentList(episodeId, page, size, sortBy, isAsc);
     }
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/EpisodeController.java
@@ -130,11 +130,11 @@ public class EpisodeController implements EpisodeControllerDocs {
 
     @GetMapping("/{episodeId}/comments")
     public Slice<EpisodeCommentListResponse> getEpisodeCommentList(
-        @PathVariable Long episodeId,
-        @RequestParam(defaultValue = "1") int page,
-        @RequestParam(defaultValue = "10") int size,
-        @RequestParam(required = false, defaultValue = "createdAt") String sortBy,
-        @RequestParam(required = false, defaultValue = "false") boolean isAsc) {
+            @PathVariable Long episodeId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false, defaultValue = "createdAt") String sortBy,
+            @RequestParam(required = false, defaultValue = "false") boolean isAsc) {
         return episodeCommentService.getEpisodeCommentList(episodeId, page, size, sortBy, isAsc);
     }
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/controller/docs/EpisodeControllerDocs.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/controller/docs/EpisodeControllerDocs.java
@@ -1,6 +1,7 @@
 package com.dopamingu.be.domain.episode.controller.docs;
 
 import com.dopamingu.be.domain.episode.dto.EpisodeCommentCreateRequest;
+import com.dopamingu.be.domain.episode.dto.EpisodeCommentListResponse;
 import com.dopamingu.be.domain.episode.dto.EpisodeCommentUpdateRequest;
 import com.dopamingu.be.domain.episode.dto.EpisodeCreateRequest;
 import com.dopamingu.be.domain.episode.dto.EpisodeCreateResponse;
@@ -15,6 +16,7 @@ import jakarta.validation.Valid;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -85,4 +87,13 @@ public interface EpisodeControllerDocs {
             @Parameter(name = "episodeId", description = "에피소드 ID") @PathVariable Long episodeId,
             @Parameter(name = "episodeCommentId", description = "에피소드 댓글 ID") @PathVariable
                     Long episodeCommentId);
+
+    @Operation(summary = "에피소드 댓글 조회", description = "특정 에피소드의 댓글을 조회합니다.")
+    @GetMapping("/{episodeId}/comments")
+    public Slice<EpisodeCommentListResponse> getEpisodeCommentList(
+        @Parameter(name = "episodeId", description = "에피소드 ID") @PathVariable Long episodeId,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "10") int size,
+        @RequestParam(required = false, defaultValue = "createdAt") String sortBy,
+        @RequestParam(required = false, defaultValue = "false") boolean isAsc);
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/domain/EpisodeComment.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/domain/EpisodeComment.java
@@ -47,8 +47,8 @@ public class EpisodeComment extends BaseTimeEntity {
     @OneToMany(mappedBy = "parent", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<EpisodeComment> subComments = new ArrayList<>();
 
-    @Column(name = "likes")
-    private int likes = 0;
+    @Column(name = "like_count")
+    private Long likeCount = 0L;
 
     @ManyToOne
     @JoinColumn(name = "episode_id")
@@ -82,11 +82,11 @@ public class EpisodeComment extends BaseTimeEntity {
         this.contentStatus = ContentStatus.DELETED;
     }
 
-    public void increaseLikes() {
-        this.likes++;
+    public void increaseLikeCount() {
+        this.likeCount++;
     }
 
-    public void decreaseLikes() {
-        this.likes--;
+    public void decreaseLikeCount() {
+        this.likeCount--;
     }
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentListResponse.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentListResponse.java
@@ -1,0 +1,69 @@
+package com.dopamingu.be.domain.episode.dto;
+
+import com.dopamingu.be.domain.episode.domain.ContentStatus;
+import com.dopamingu.be.domain.episode.domain.EpisodeComment;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EpisodeCommentListResponse {
+
+    private Long id;
+    private String creatorName;
+    private ContentStatus contentStatus;
+    private String content;
+    private Long likeCount;
+    private boolean isLiked; // 사용자 좋아요 여부
+    private List<EpisodeSubComment> subCommentList;
+    private LocalDateTime createdAt;
+
+    public static EpisodeCommentListResponse fromEntity(EpisodeComment episodeComment) {
+        return EpisodeCommentListResponse.builder()
+            .id(episodeComment.getId())
+            .creatorName(episodeComment.getCreatorName())
+            .contentStatus(episodeComment.getContentStatus())
+            .likeCount(episodeComment.getLikeCount())
+            .isLiked(false)
+            .subCommentList(episodeComment.getSubComments().stream()
+                .map(EpisodeSubComment::fromSubCommentEntity)
+                .toList())
+            .createdAt(episodeComment.getCreatedAt())
+            .build();
+    }
+
+    public void isLikedComment() {
+        this.isLiked = true;
+    }
+
+    @Getter
+    @Builder
+    public static class EpisodeSubComment {
+
+        private Long id;
+        private String creatorName;
+        private ContentStatus contentStatus;
+        private String content;
+        private Long likeCount;
+        private boolean isLiked; // 사용자 좋아요 여부
+        private LocalDateTime createdAt;
+
+        public static EpisodeSubComment fromSubCommentEntity(EpisodeComment subComment) {
+            return EpisodeSubComment.builder()
+                .id(subComment.getId())
+                .creatorName(subComment.getCreatorName())
+                .contentStatus(subComment.getContentStatus())
+                .likeCount(subComment.getLikeCount())
+                .isLiked(false)
+                .createdAt(subComment.getCreatedAt())
+                .build();
+        }
+
+        public void isLikedSubComment() {
+            this.isLiked = true;
+        }
+    }
+
+}

--- a/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentListResponse.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/dto/EpisodeCommentListResponse.java
@@ -22,16 +22,17 @@ public class EpisodeCommentListResponse {
 
     public static EpisodeCommentListResponse fromEntity(EpisodeComment episodeComment) {
         return EpisodeCommentListResponse.builder()
-            .id(episodeComment.getId())
-            .creatorName(episodeComment.getCreatorName())
-            .contentStatus(episodeComment.getContentStatus())
-            .likeCount(episodeComment.getLikeCount())
-            .isLiked(false)
-            .subCommentList(episodeComment.getSubComments().stream()
-                .map(EpisodeSubComment::fromSubCommentEntity)
-                .toList())
-            .createdAt(episodeComment.getCreatedAt())
-            .build();
+                .id(episodeComment.getId())
+                .creatorName(episodeComment.getCreatorName())
+                .contentStatus(episodeComment.getContentStatus())
+                .likeCount(episodeComment.getLikeCount())
+                .isLiked(false)
+                .subCommentList(
+                        episodeComment.getSubComments().stream()
+                                .map(EpisodeSubComment::fromSubCommentEntity)
+                                .toList())
+                .createdAt(episodeComment.getCreatedAt())
+                .build();
     }
 
     public void isLikedComment() {
@@ -52,18 +53,17 @@ public class EpisodeCommentListResponse {
 
         public static EpisodeSubComment fromSubCommentEntity(EpisodeComment subComment) {
             return EpisodeSubComment.builder()
-                .id(subComment.getId())
-                .creatorName(subComment.getCreatorName())
-                .contentStatus(subComment.getContentStatus())
-                .likeCount(subComment.getLikeCount())
-                .isLiked(false)
-                .createdAt(subComment.getCreatedAt())
-                .build();
+                    .id(subComment.getId())
+                    .creatorName(subComment.getCreatorName())
+                    .contentStatus(subComment.getContentStatus())
+                    .likeCount(subComment.getLikeCount())
+                    .isLiked(false)
+                    .createdAt(subComment.getCreatedAt())
+                    .build();
         }
 
         public void isLikedSubComment() {
             this.isLiked = true;
         }
     }
-
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentLikeRepository.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentLikeRepository.java
@@ -20,9 +20,7 @@ public interface EpisodeCommentLikeRepository extends JpaRepository<EpisodeComme
                     Long episodeId, Long episodeCommentId, Long memberId, LikeStatus likeStatus);
 
     @Query(
-        "SELECT ecl.episodeComment.id FROM EpisodeCommentLike ecl WHERE ecl.episode.id = :episodeId and ecl.member.id = :memberId"
-    )
-    Set<Long> findEpisodeCommentLikeIds(@Param("episodeId") Long episodeId,
-        @Param("memberId") Long memberId);
-
+            "SELECT ecl.episodeComment.id FROM EpisodeCommentLike ecl WHERE ecl.episode.id = :episodeId and ecl.member.id = :memberId")
+    Set<Long> findEpisodeCommentLikeIds(
+            @Param("episodeId") Long episodeId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentLikeRepository.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentLikeRepository.java
@@ -5,7 +5,10 @@ import com.dopamingu.be.domain.episode.domain.EpisodeCommentLike;
 import com.dopamingu.be.domain.episode.domain.LikeStatus;
 import com.dopamingu.be.domain.member.domain.Member;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface EpisodeCommentLikeRepository extends JpaRepository<EpisodeCommentLike, Long> {
 
@@ -15,4 +18,11 @@ public interface EpisodeCommentLikeRepository extends JpaRepository<EpisodeComme
     Optional<EpisodeCommentLike>
             findEpisodeCommentLikeByEpisode_IdAndEpisodeComment_IdAndMember_IdAndLikeStatus(
                     Long episodeId, Long episodeCommentId, Long memberId, LikeStatus likeStatus);
+
+    @Query(
+        "SELECT ecl.episodeComment.id FROM EpisodeCommentLike ecl WHERE ecl.episode.id = :episodeId and ecl.member.id = :memberId"
+    )
+    Set<Long> findEpisodeCommentLikeIds(@Param("episodeId") Long episodeId,
+        @Param("memberId") Long memberId);
+
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
@@ -28,5 +28,4 @@ public interface EpisodeCommentRepository extends JpaRepository<EpisodeComment, 
             EpisodeComment episodeComment);
 
     Page<EpisodeComment> findAllByEpisodeIdAndParentIsNull(Pageable pageable, Long episodeId);
-
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/repository/EpisodeCommentRepository.java
@@ -4,6 +4,8 @@ import com.dopamingu.be.domain.episode.domain.ContentStatus;
 import com.dopamingu.be.domain.episode.domain.Episode;
 import com.dopamingu.be.domain.episode.domain.EpisodeComment;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,4 +26,7 @@ public interface EpisodeCommentRepository extends JpaRepository<EpisodeComment, 
             ContentStatus contentStatus,
             Episode episode,
             EpisodeComment episodeComment);
+
+    Page<EpisodeComment> findAllByEpisodeIdAndParentIsNull(Pageable pageable, Long episodeId);
+
 }

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentLikeService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentLikeService.java
@@ -62,7 +62,7 @@ public class EpisodeCommentLikeService {
                 .orElseGet(() -> createEpisodeCommentLike(member, episodeComment, episode));
 
         // episodeComment 의 likes 숫자 +1
-        episodeComment.increaseLikes();
+        episodeComment.increaseLikeCount();
 
         return episodeComment.getId();
     }
@@ -77,7 +77,7 @@ public class EpisodeCommentLikeService {
 
         // episodeComment 의 likes 숫자 -1
         EpisodeComment episodeComment = episodeCommentLike.getEpisodeComment();
-        episodeComment.decreaseLikes();
+        episodeComment.decreaseLikeCount();
     }
 
     private Episode getValidEpisode(Long episodeId) {

--- a/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
+++ b/src/main/java/com/dopamingu/be/domain/episode/service/EpisodeCommentService.java
@@ -36,7 +36,7 @@ public class EpisodeCommentService {
 
     public EpisodeCommentService(
             EpisodeCommentRepository episodeCommentRepository,
-        EpisodeCommentLikeRepository episodeCommentLikeRepository,
+            EpisodeCommentLikeRepository episodeCommentLikeRepository,
             EpisodeRepository episodeRepository,
             MemberUtil memberUtil) {
         this.episodeCommentRepository = episodeCommentRepository;
@@ -97,8 +97,8 @@ public class EpisodeCommentService {
         episodeComment.deleteEpisodeComment();
     }
 
-    public Slice<EpisodeCommentListResponse> getEpisodeCommentList(Long episodeId, int page,
-        int size, String sortBy, boolean isAsc) {
+    public Slice<EpisodeCommentListResponse> getEpisodeCommentList(
+            Long episodeId, int page, int size, String sortBy, boolean isAsc) {
         // 회원 확인
         Member member = memberUtil.getCurrentMember();
 
@@ -106,21 +106,24 @@ public class EpisodeCommentService {
         Episode episode = getValidEpisode(episodeId);
 
         // episode comment 만 먼저 찾기
-        Slice<EpisodeComment> comments = episodeCommentRepository.findAllByEpisodeIdAndParentIsNull(
-            getPageable(page, size, sortBy, isAsc), episode.getId());
+        Slice<EpisodeComment> comments =
+                episodeCommentRepository.findAllByEpisodeIdAndParentIsNull(
+                        getPageable(page, size, sortBy, isAsc), episode.getId());
 
-        Slice<EpisodeCommentListResponse> commentListResponses = comments.map(
-            EpisodeCommentListResponse::fromEntity);
+        Slice<EpisodeCommentListResponse> commentListResponses =
+                comments.map(EpisodeCommentListResponse::fromEntity);
 
         // 회원이 있는 경우에만 좋아요 여부 업데이트
         if (member != null) {
-            Set<Long> episdoeLikeIdSet = episodeCommentLikeRepository.findEpisodeCommentLikeIds(
-                episodeId, member.getId());
+            Set<Long> episdoeLikeIdSet =
+                    episodeCommentLikeRepository.findEpisodeCommentLikeIds(
+                            episodeId, member.getId());
             for (EpisodeCommentListResponse comment : commentListResponses) {
                 if (episdoeLikeIdSet.contains(comment.getId())) {
                     comment.isLikedComment();
                 }
-                for (EpisodeCommentListResponse.EpisodeSubComment subComment : comment.getSubCommentList()) {
+                for (EpisodeCommentListResponse.EpisodeSubComment subComment :
+                        comment.getSubCommentList()) {
                     if (episdoeLikeIdSet.contains(subComment.getId())) {
                         subComment.isLikedSubComment();
                     }
@@ -177,7 +180,7 @@ public class EpisodeCommentService {
 
     private Episode getValidEpisode(Long episodeId) {
         return episodeRepository
-            .findEpisodeByIdAndContentStatus(episodeId, ContentStatus.NORMAL)
+                .findEpisodeByIdAndContentStatus(episodeId, ContentStatus.NORMAL)
                 .orElseThrow(() -> new CustomException(ErrorCode.EPISODE_NOT_FOUND));
     }
 
@@ -225,5 +228,4 @@ public class EpisodeCommentService {
         Sort sort = Sort.by(direction, sortBy);
         return PageRequest.of(page - 1, size, sort);
     }
-
 }


### PR DESCRIPTION
## 💡 Issue
- #50 

## 📌 Work Description

- 에피소드의 댓글 목록을 페이징하여 조회하는 기능 구현
- 댓글과 대댓글을 계층 구조로 반환 (댓글 아래 대댓글 목록 포함)
- 로그인한 사용자의 경우 각 댓글/대댓글에 대한 좋아요 여부 표시
- 정렬 조건(sortBy)과 정렬 방향(isAsc)을 파라미터로 받아 유연한 정렬 지원
- Slice를 사용하여 무한 스크롤 방식의 페이징 구현

## ✅ 테스트 항목

### 페이징 처리
- [x] 지정된 size만큼 댓글이 조회되는지 확인
- [x] 다음 페이지 존재 여부가 정확히 반환되는지 확인
- [x] 정렬 조건에 따라 올바르게 정렬되는지 확인
### 계층 구조 조회
- [x] 메인 댓글만 페이징되어 조회되는지 확인
- [x] 각 메인 댓글의 대댓글이 모두 포함되는지 확인
### 좋아요 상태 표시
- [x] 로그인 사용자의 좋아요한 댓글 표시 확인
- [x] 로그인 사용자의 좋아요한 대댓글 표시 확인
### 예외 처리
- [x] 존재하지 않는 에피소드 조회 시 예외 발생 확인
- [x] 잘못된 페이징 파라미터 입력 시 처리 확인

## 📝 Reference
- 

## 📚 Etc
- 
